### PR TITLE
Update to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Super-Linter](https://github.com/karpikpl/pylint-action/actions/workflows/linter.yml/badge.svg)](https://github.com/super-linter/super-linter)
 ![CI](https://github.com/karpikpl/pylint-action/actions/workflows/ci.yml/badge.svg)
 
-GitHub action that lints files that were changed in a PR and annotates
+GitHub Action that lints files that were changed in a PR and annotates
 them with pylint comments.
 
 ![Linting result](img/image.png)

--- a/README.md
+++ b/README.md
@@ -21,22 +21,22 @@ permissions:
 ```
 
 ```yaml
-uses: karpikpl/pylint-action@1.0.1
+uses: karpikpl/pylint-action@1.1.0
 ```
 
 To specify python version:
 
 ```yaml
-uses: karpikpl/pylint-action@1.0.1
+uses: karpikpl/pylint-action@1.1.0
 with:
-  python-version: '3.11'
+  python-version: '3.13'
 ```
 
 ## Inputs
 
 ### `python-version`
 
-**Optional** Version of python to use. Defaults to `3.11`.
+**Optional** Version of python to use. Defaults to `3.13`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   python-version:
     description: 'Python version to use'
     required: true
-    default: '3.11'
+    default: '3.13'
 outputs:
   result:
     description: "Result of the lint action"
@@ -51,7 +51,7 @@ runs:
         echo "exitcode=$TASK_EXIT_CODE" >> $GITHUB_OUTPUT
 
     - name: Annotate Commit with Pylint Results
-      uses: karpikpl/pylint-annotation-action@v1.0.1
+      uses: karpikpl/pylint-annotation-action@v1.1.0
       id: pylint-annotation
       with:
         head-sha: ${{ steps.changed_files.outputs.head_sha || github.sha }}


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `action.yml` files to upgrade the `pylint-action` and `pylint-annotation-action` versions, and to change the default Python version.

Version upgrades:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R39): Updated `pylint-action` version from `1.0.1` to `1.1.0` and default Python version from `3.11` to `3.13`.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L9-R9): Updated `pylint-action` version from `1.0.1` to `1.1.0` and default Python version from `3.11` to `3.13`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L9-R9) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L54-R54)